### PR TITLE
Extract attributes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.1
+current_version = 5.0.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## 5.0.1
+
+### Added
+
+- `Mentee` objects can specify a quality they'd like their `Mentor` to have, and `Mentor`s can specify a range of qualities they have. This might be professional skills, like 'software development' or 'cattle wrangling'. Alternatively, if you are targeting under-represented groups, this might be a gender, sexual, or racial identity.
+
+## 5.0.0 2022-04-14
+
+### Changed
+
+- The `Person` object must now be instantiated from a simpler dictionary, with one-word keys. See the example csv for what those are
+- Oh, I added an example csv file!
+- `profession` has been renamed to `current_profession`
+
+### Removed
+
+- `Person.grade` is now always an `int`. This generalises the software away from a purely Civil Service basis, but does mean that users are required to do their own mapping of integers to human-readable strings
+
+### Added
+
+- `Mentee` objects now have a `target_profession` as well as a `current_profession`
+- There is now a `Generic` rule object, where you can pass a `lambda` if your condition is nice and simple. Or even if it's not, I'm not the boss of you.
+
 ## 4.0.0 2022-03-20
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can install this project with `python -m pip install mentor-match`
 ## Use
 
 To use this library, first install it (see above). You may need to munge your data for the system to be happy with it.
-Use the attached CSV files as guides for your mentor and mentee data, then put them together in the same folder.
+Use the [example CSV file](example.csv) as guides for your mentor and mentee data, then put them together in the same folder.
 
 The software will run three matching exercises. Participants who don't match in the first round are more heavily
 weighted in the next round. The aim is to improve the experience for everyone.
@@ -24,11 +24,11 @@ weighted in the next round. The aim is to improve the experience for everyone.
 The weightings are as follows:
 
 
-| property            | First run | Second run | Third run |
-|---------------------|-----------|------------|-----------|
-| **profession**      | 4         | 4          | 0         |
-| **grade**           | 3         | 3          | 3         |
-| **unmatched bonus** | 0         | 50         | 100       |
+| property                                                          | First run | Second run | Third run |
+|-------------------------------------------------------------------|-----------|------------|-----------|
+| **mentee's target profession is the same as mentor's profession** | 4         | 4          | 0         |
+| **grade is one or two grades different**                          | 3         | 3          | 3         |
+| **bonus for anyone's who's not got a match yet**                  | 0         | 50         | 100       |
 
 
 Here is a snippet that outlines a minimal use in a Python project:

--- a/example.csv
+++ b/example.csv
@@ -1,0 +1,1 @@
+role_type,first name,last name,email,role,organisation,grade,current profession,target profession

--- a/matching/factory.py
+++ b/matching/factory.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from matching.mentee import Mentee
 from matching.mentor import Mentor
-from matching.person import GRADES, Person
+from matching.person import Person
 
 
 class ParticipantFactory:
@@ -13,17 +13,12 @@ class ParticipantFactory:
         participant_type_str = list(data_as_dict).pop()
         participant_type = cls.participant_types.get(participant_type_str, Person)
         participant_data = data_as_dict.get(participant_type_str, dict())
-        participant = participant_type()
-        participant._grade = GRADES.index(participant_data["grade"])
-        participant.department = participant_data["department"]
-        participant.profession = participant_data["profession"]
-        participant.email = participant_data["email"]
-        participant.first_name = participant_data["first name"]
-        participant.last_name = participant_data["last name"]
-        participant.role = participant_data["role"]
+        participant = participant_type(**participant_data)
         connections: List[Dict[str, str]] = participant_data.get("connections", [])
         participant._connections = [
             ParticipantFactory.create_from_dict(connection_data)
             for connection_data in connections
         ]
+        if type(participant) is Mentee:
+            participant.target_profession = participant_data["target profession"]
         return participant

--- a/matching/match.py
+++ b/matching/match.py
@@ -30,7 +30,7 @@ class Match:
         self._disallowed: bool = False
         self._score: int = 0
         self.rules = [
-            rl.Disqualify(lambda match: match.mentor == match.mentee),
+            rl.Disqualify(lambda match: match.mentor.email == match.mentee.email),
             rl.Disqualify(
                 lambda match: match.mentor in match.mentee.mentors
                 or match.mentee in match.mentor.mentees

--- a/matching/mentee.py
+++ b/matching/mentee.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Union, List
 from matching.person import Person
 
 if TYPE_CHECKING:
@@ -7,6 +7,14 @@ if TYPE_CHECKING:
 
 class Mentee(Person):
     def __init__(self, **kwargs):
+        """
+        Mentees should have a target profession. If they don't have a target profession, we assume it's the same one
+        they're in at the moment
+        :param kwargs:
+        """
+        self.target_profession = kwargs.get(
+            "target profession", kwargs.get("current profession")
+        )
         super(Mentee, self).__init__(**kwargs)
 
     @property
@@ -16,3 +24,8 @@ class Mentee(Person):
     @mentors.setter
     def mentors(self, new_mentor: "Mentor"):
         super(Mentee, self).connections.append(new_mentor)
+
+    def core_to_dict(self) -> Dict[str, Dict[str, Union[str, List]]]:
+        core = super(Mentee, self).core_to_dict()
+        core["mentee"]["target profession"] = self.target_profession
+        return core

--- a/matching/person.py
+++ b/matching/person.py
@@ -1,42 +1,22 @@
 from typing import List, Dict, Union
 
-GRADES = [
-    "AA",
-    "AO",
-    "EO",
-    "HEO",
-    "SEO",
-    "Grade 7",
-    "Grade 6",
-    "SCS1",
-    "SCS2",
-    "SCS3",
-    "SCS4",
-]
-
 
 class Person:
     def __init__(self, **kwargs):
-        self._grade: int = GRADES.index(kwargs.get("Your grade", "AA"))
-        self.department: str = kwargs.get("Your department or agency", None)
-        self.profession: str = kwargs.get("Your profession", None)
-        self.email = kwargs.get("Your Civil Service email address", None)
-        self.first_name = kwargs.get("Your first name", None)
-        self.last_name = kwargs.get("Your last name", None)
-        self.role = kwargs.get("Your job title or role", None)
+        """
+        When creating a person from a dictionary, we expect a grade as an integer. The lower the `int`, the lower the
+        grade. It is the client's responsibility to turn this integer back into a human-readable `str` if needed
+        :param kwargs:
+        """
+        self.grade: int = int(kwargs.get("grade"))
+        self.organisation: str = kwargs.get("organisation", None)
+        self.current_profession: str = kwargs.get("current profession", None)
+        self.email = kwargs.get("email", None)
+        self.first_name = kwargs.get("first name", None)
+        self.last_name = kwargs.get("last name", None)
+        self.role = kwargs.get("role", None)
         self._connections: List[Person] = []
         self.has_no_match: bool = False
-
-    @property
-    def grade(self):
-        return self._grade
-
-    @grade.setter
-    def grade(self, new_grade: str):
-        if new_grade in GRADES:
-            self._grade = GRADES.index(new_grade)
-        else:
-            raise NotImplementedError
 
     @property
     def connections(self) -> List["Person"]:
@@ -65,9 +45,9 @@ class Person:
                 "first name": self.first_name,
                 "last name": self.last_name,
                 "role": self.role,
-                "department": self.department,
-                "grade": GRADES[self.grade],
-                "profession": self.profession,
+                "organisation": self.organisation,
+                "grade": self.grade,
+                "current profession": self.current_profession,
             }
         }
 

--- a/matching/person.py
+++ b/matching/person.py
@@ -83,6 +83,4 @@ class Person:
         return self.__class__.__name__.lower()
 
     def __eq__(self, other: "Person"):
-        return other.to_dict().get(other.class_name()) == self.to_dict().get(
-            self.class_name()
-        )
+        return self.email == other.email

--- a/matching/process.py
+++ b/matching/process.py
@@ -106,7 +106,9 @@ def process_data(
     """
     if not all_rules:
         base_rules: List[rl.AbstractRule] = [
-            rl.Disqualify(rl.Equivalent("department").evaluate),
+            rl.Disqualify(
+                lambda match: match.mentee.organisation == match.mentor.organisation
+            ),
             rl.Disqualify(
                 rl.Grade(target_diff=2, logical_operator=operator.gt).evaluate
             ),
@@ -119,8 +121,10 @@ def process_data(
             unique_rules = [
                 rl.Grade(1, operator.eq, {True: match_round.get("grade", 3), False: 0}),
                 rl.Grade(2, operator.eq, {True: match_round.get("grade", 6), False: 0}),
-                rl.Equivalent(
-                    "profession", {True: match_round.get("profession", 0), False: 0}
+                rl.Generic(
+                    {True: match_round.get("profession", 0), False: 0},
+                    lambda match: match.mentee.target_profession
+                    == match.mentor.current_profession,
                 ),
                 rl.UnmatchedBonus(match_round.get("unmatched bonus", 0)),
             ]

--- a/matching/rules/rule.py
+++ b/matching/rules/rule.py
@@ -83,16 +83,16 @@ class Generic(Rule):
         return self._evaluate(match_object)
 
 
-class Disqualify(AbstractRule):
+class Disqualify(Generic):
     """
     A disqualifying rule is a kind of anti-rule. Here, we pass a condition which, if it evaluates to `True`, should
     disqualify a `Match` rather than increase its score.
     """
 
     def __init__(self, disqualifying_condition: Callable[["Match"], bool]):
-        self.condition = disqualifying_condition
+        super(Disqualify, self).__init__(None, disqualifying_condition)
 
     def apply(self, match_object: "Match") -> int:
-        if self.condition(match_object):
+        if super(Disqualify, self).evaluate(match_object):
             match_object.disallowed = True
         return 0

--- a/matching/rules/rule.py
+++ b/matching/rules/rule.py
@@ -70,6 +70,19 @@ class Equivalent(Rule):
         return operator.eq(*attrs)
 
 
+class Generic(Rule):
+    def __init__(
+        self,
+        score_dict: Union[Dict[bool, int], None],
+        evaluation_func: Callable[["Match"], bool],
+    ):
+        super(Generic, self).__init__(score_dict)
+        self._evaluate = evaluation_func
+
+    def evaluate(self, match_object: "Match") -> bool:
+        return self._evaluate(match_object)
+
+
 class Disqualify(AbstractRule):
     """
     A disqualifying rule is a kind of anti-rule. Here, we pass a condition which, if it evaluates to `True`, should

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="4.0.1",
+    version="5.0.0",
     description="A series of classes to match mentors and mentees",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import pytest as pytest
 from matching.mentee import Mentee
 from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path
-from datetime import datetime
 import math
 import csv
 
@@ -15,31 +14,29 @@ def known_file(base_data):
         data_path = path_to_file / f"{role_type}s.csv"
         with open(data_path, "w", newline="") as test_data:
             headings = [
-                "Timestamp",
-                f"Do you want to sign up as a {role_type}?",
-                "Do you agree to us using the information you provide to us in this way?",
-                "Your first name",
-                "Your last name",
-                "Your Civil Service email address",
-                "Your job title or role",
-                "Your department or agency",
-                "Your grade",
-                "Your profession",
+                role_type,
+                "first name",
+                "last name",
+                "email",
+                "role",
+                "organisation",
+                "grade",
+                "current profession",
+                "target profession",
             ]
             data = [headings]
             for i in range(quantity):
                 data.append(
                     [
-                        str(datetime.now()),
-                        "yes",
                         "yes",
                         role_type,
                         str(i).zfill(padding_size),
                         f"{role_type}.{str(i).zfill(padding_size)}@gov.uk",
                         "Some role",
                         f"Department of {role_type.capitalize()}s",
-                        "EO" if role_type == "mentor" else "AA",
-                        "Participant",
+                        2 if role_type == "mentor" else 0,
+                        "Policy",
+                        "Policy",
                     ]
                 )
             file_writer = csv.writer(test_data)
@@ -65,24 +62,26 @@ def test_participants(test_data_path, known_file):
 @pytest.fixture
 def base_data() -> dict:
     return {
-        "Your first name": "Test",
-        "Your last name": "Data",
-        "Your Civil Service email address": "test@data.com",
-        "Your job title or role": "N/A",
-        "Your department or agency": "Department of Fun",
-        "Your grade": "Grade 7",
-        "Your profession": "Policy",
+        "first name": "Test",
+        "last name": "Data",
+        "email": "test@data.com",
+        "role": "N/A",
+        "organisation": "Department of Fun",
+        "grade": 5,
+        "current profession": "Policy",
     }
 
 
 @pytest.fixture
 def base_mentee(base_data):
-    return Mentee(**base_data)
+    mentee = Mentee(**base_data)
+    mentee.target_profession = "Policy"
+    return mentee
 
 
 @pytest.fixture
 def base_mentor(base_data):
     data_copy = base_data.copy()
-    data_copy["Your grade"] = "Grade 6"
-    data_copy["Your department or agency"] = "Ministry of Silly Walks"
+    data_copy["grade"] = 6
+    data_copy["organisation"] = "Ministry of Silly Walks"
     return Mentor(**data_copy)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -5,7 +5,6 @@ import matching.rules.rule as rl
 from matching.match import Match
 from matching.mentor import Mentor
 from matching.mentee import Mentee
-from matching.person import GRADES
 import pytest
 
 
@@ -18,20 +17,22 @@ class TestMatch:
     def test_cant_match_with_same_department(
         self, base_mentee: Mentee, base_mentor: Mentor
     ):
-        base_mentee.department = base_mentor.department = "Department of Fun"
+        base_mentee.organisation = base_mentor.organisation = "Department of Fun"
         match = TestMatch.new_match(
             mentor=base_mentor,
             mentee=base_mentee,
             rules=[
-                rl.Disqualify(rl.Equivalent("department", {True: 0, False: 0}).evaluate)
+                rl.Disqualify(
+                    rl.Equivalent("organisation", {True: 0, False: 0}).evaluate
+                )
             ],
         )
         match.calculate_match()
         assert match.disallowed
 
     @pytest.mark.integration
-    @pytest.mark.parametrize("mentee_grade", [grade for grade in GRADES])
-    @pytest.mark.parametrize("mentor_grade", [grade for grade in GRADES])
+    @pytest.mark.parametrize("mentee_grade", range(11))
+    @pytest.mark.parametrize("mentor_grade", range(11))
     def test_cant_match_with_greater_than_two_grade_difference(
         self, base_mentee, base_mentor, mentee_grade, mentor_grade
     ):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -38,6 +38,9 @@ class TestMatch:
         base_mentee.grade = mentee_grade
         base_mentor.grade = mentor_grade
 
+        base_mentee.email = "mentee"
+        base_mentor.email = "mentor"
+
         match = TestMatch.new_match(
             mentor=base_mentor,
             mentee=base_mentee,
@@ -65,6 +68,7 @@ class TestMatch:
 
     def test_cant_match_with_self(self, base_mentee, base_data):
         mentor = Mentor(**base_data)
+        mentor.email = base_mentee.email = "same@email.com"
         match = TestMatch.new_match(mentor=mentor, mentee=base_mentee, rules=[])
         match.calculate_match()
         assert match.disallowed

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -13,7 +13,11 @@ def test_match(base_mentor, base_mentee):
 
 class TestRules:
     def test_matching_scores_scores_correct_points(self, test_match):
-        profession_rule = rl.Equivalent("profession", {True: 4, False: 0})
+        profession_rule = rl.Generic(
+            {True: 4, False: 0},
+            lambda match: match.mentee.target_profession
+            == match.mentor.current_profession,
+        )
         assert profession_rule.apply(test_match) == 4
 
     @pytest.mark.parametrize("mentee_grade", [grade for grade in range(11)])


### PR DESCRIPTION
# Summary

This brings a number of breaking changes. Please don't update this library without checking everything works first!!

# Changelog

## 5.0.0 2022-04-14

### Changed

- The `Person` object must now be instantiated from a simpler dictionary, with one-word keys. See the example csv for what those are
- Oh, I added an example csv file!
- `profession` has been renamed to `current_profession`

### Removed

- `Person.grade` is now always an `int`. This generalises the software away from a purely Civil Service basis, but does mean that users are required to do their own mapping of integers to human-readable strings

### Added

- `Mentee` objects now have a `target_profession` as well as a `current_profession`
- There is now a `Generic` rule object, where you can pass a `lambda` if your condition is nice and simple. Or even if it's not, I'm not the boss of you.

