### PR TITLE
Add csv mapping func

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.0
+current_version = 5.1.0
 commit = True
 tag = True
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     -   id: black
         args: [--experimental-string-processing]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,46 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## 5.0.1
+## Added
+
+- `Mentee` objects can specify a quality they'd like their `Mentor` to have, and `Mentor`s can specify a range of
+  qualities they have. This might be professional skills, like 'software development' or 'cattle wrangling'.
+  Alternatively, if you are targeting under-represented groups, this might be a gender, sexual, or racial identity.
+
+## 5.1.0 2022-04-15
 
 ### Added
 
-- `Mentee` objects can specify a quality they'd like their `Mentor` to have, and `Mentor`s can specify a range of qualities they have. This might be professional skills, like 'software development' or 'cattle wrangling'. Alternatively, if you are targeting under-represented groups, this might be a gender, sexual, or racial identity.
+- Users can pass a mapping function to `create_participant_list_from_path`. The function will be passed
+  a `dict[str, str]`, representing a row in the user-uploaded spreadsheet, and can also access a string representation
+  of the type of participant - "mentor" or "mentee". This function is optional, but the software will break in ugly
+  ways if your spreadsheet doesn't have the headings in the [example csv file](./example.csv). It can have others,
+  but they'll be ignored
+
+### Changed
+
+- I've updated the csv file and removed the "role type" heading, because it's currently not important. I will put an
+  issue on the roadmap to allow users to upload a single spreadsheet with everyone on it
 
 ## 5.0.0 2022-04-14
 
 ### Changed
 
-- The `Person` object must now be instantiated from a simpler dictionary, with one-word keys. See the example csv for what those are
+- The `Person` object must now be instantiated from a simpler dictionary, with one-word keys. See the example csv for
+  what those are
 - Oh, I added an example csv file!
 - `profession` has been renamed to `current_profession`
 
 ### Removed
 
-- `Person.grade` is now always an `int`. This generalises the software away from a purely Civil Service basis, but does mean that users are required to do their own mapping of integers to human-readable strings
+- `Person.grade` is now always an `int`. This generalises the software away from a purely Civil Service basis, but does
+  mean that users are required to do their own mapping of integers to human-readable strings
 
 ### Added
 
 - `Mentee` objects now have a `target_profession` as well as a `current_profession`
-- There is now a `Generic` rule object, where you can pass a `lambda` if your condition is nice and simple. Or even if it's not, I'm not the boss of you.
+- There is now a `Generic` rule object, where you can pass a `lambda` if your condition is nice and simple. Or even if
+  it's not, I'm not the boss of you.
 
 ## 4.0.0 2022-03-20
 
@@ -40,12 +58,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   **non-breaking**.
 
 ### Added
+
 - A `Rule` class, which describes the rules to be used for scoring `Match` objects. All `Rule` subclasses must implement
-an `evaluate` method that takes a `Match` object and returns a `bool`
+  an `evaluate` method that takes a `Match` object and returns a `bool`
 
 ### Deprecated
+
 - In the next release, clients will create `Rule` objects with scores, and `weighting_list` will not be passed to
-`process_data`
+  `process_data`
+
 ## 3.0.0 2022-03-13
 
 ### Removed

--- a/example.csv
+++ b/example.csv
@@ -1,1 +1,1 @@
-role_type,first name,last name,email,role,organisation,grade,current profession,target profession
+first name,last name,email,role,organisation,grade,current profession,target profession

--- a/matching/process.py
+++ b/matching/process.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import sys
 from pathlib import Path
-from typing import Union, Type, List, Dict, Tuple, Generator, Optional
+from typing import Union, Type, List, Dict, Tuple, Generator, Optional, Callable
 
 from munkres import Munkres, make_cost_matrix, Matrix  # type: ignore
 
@@ -38,10 +38,17 @@ def process_form(path_to_form) -> Generator[Dict[str, str], None, None]:
 
 
 def create_participant_list_from_path(
-    participant: Union[Type[Mentee], Type[Mentor]], path_to_data: pathlib.Path
+    participant: Union[Type[Mentee], Type[Mentor]],
+    path_to_data: pathlib.Path,
+    mapping_func: Optional[
+        Callable[[dict[str, str], str], dict[str, str]]
+    ] = lambda row, name: row,
 ):
     path_to_data = path_to_data / f"{participant.__name__.lower()}s.csv"
-    return [participant(**row) for row in process_form(path_to_data)]
+    return [
+        participant(**mapping_func(row, participant.__name__.lower()))
+        for row in process_form(path_to_data)
+    ]
 
 
 def transpose_matrix(matrix):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="5.0.0",
+    version="5.1.0",
     description="A series of classes to match mentors and mentees",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ def known_file(base_data):
         data_path = path_to_file / f"{role_type}s.csv"
         with open(data_path, "w", newline="") as test_data:
             headings = [
-                role_type,
                 "first name",
                 "last name",
                 "email",
@@ -28,7 +27,6 @@ def known_file(base_data):
             for i in range(quantity):
                 data.append(
                     [
-                        "yes",
                         role_type,
                         str(i).zfill(padding_size),
                         f"{role_type}.{str(i).zfill(padding_size)}@gov.uk",


### PR DESCRIPTION
## 5.1.0 2022-04-15

### Added

- Users can pass a mapping function to `create_participant_list_from_path`. The function will be passed
  a `dict[str, str]`, representing a row in the user-uploaded spreadsheet, and can also access a string representation
  of the type of participant - "mentor" or "mentee". This function is optional, but the software will break in ugly
  ways if your spreadsheet doesn't have the headings in the [example csv file](./example.csv). It can have others,
  but they'll be ignored

### Changed

- I've updated the csv file and removed the "role type" heading, because it's currently not important. I will put an
  issue on the roadmap to allow users to upload a single spreadsheet with everyone on it