### PR TITLE
Fix class naming

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = True
 

--- a/matching/mentee.py
+++ b/matching/mentee.py
@@ -27,5 +27,5 @@ class Mentee(Person):
 
     def core_to_dict(self) -> Dict[str, Dict[str, Union[str, List]]]:
         core = super(Mentee, self).core_to_dict()
-        core["mentee"]["target profession"] = self.target_profession
+        core[self.class_name()]["target profession"] = self.target_profession
         return core

--- a/matching/person.py
+++ b/matching/person.py
@@ -33,14 +33,14 @@ class Person:
         self,
     ) -> Dict[str, Dict[str, Union[str, List[Dict[str, Dict[str, str]]]]]]:
         output = self.core_to_dict()
-        output[self.__class__.__name__.lower()]["connections"] = [
+        output[self.class_name()]["connections"] = [
             connection.core_to_dict() for connection in self.connections
         ]
         return output
 
     def core_to_dict(self) -> Dict[str, Dict[str, Union[str, List]]]:
         return {
-            self.__class__.__name__.lower(): {
+            self.class_name(): {
                 "email": self.email,
                 "first name": self.first_name,
                 "last name": self.last_name,
@@ -52,7 +52,7 @@ class Person:
         }
 
     def to_dict_for_output(self, depth=1) -> dict:
-        output = self.core_to_dict()[self.__class__.__name__.lower()]
+        output = self.core_to_dict()[self.class_name()]
         if depth == 1:
             for i, connection in enumerate(self._connections):
                 for key, value in connection.to_dict_for_output(depth=0).items():

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="5.1.0",
+    version="5.1.1",
     description="A series of classes to match mentors and mentees",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This makes a minor change, where the method on `Mentee` that outputs to a dictionary is updated to use the instance method `class_name`. This will enable subclasses to also use `class_name` and not worry about hard-coded class names in the parent class mucking up the dictionary.