### PR TITLE
Add export function

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.3
+current_version = 5.1.4
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## Added
+## 5.1.4 2022-05-08
 
-- `Mentee` objects can specify a quality they'd like their `Mentor` to have, and `Mentor`s can specify a range of
-  qualities they have. This might be professional skills, like 'software development' or 'cattle wrangling'.
-  Alternatively, if you are targeting under-represented groups, this might be a gender, sexual, or racial identity.
+### Added
+
+- The `Person` base class now has a method `to_dict_for_export`. This could be useful if users want a different
+  representation for exporting - for example, if they don't need every attribute on the model, or they want to do
+  some calculations before exporting. By default, it just calls `to_dict_for_output`. In a future major version,
+  this method will be renamed simply to `to_dict`, to reflect that it's a full representation of the model.
 
 ## 5.1.0 2022-04-15
 

--- a/matching/person.py
+++ b/matching/person.py
@@ -59,6 +59,14 @@ class Person:
                     output[f"match {i + 1} {key}"] = value
         return output
 
+    def to_dict_for_export(self, depth=1) -> dict:
+        """
+        This method converts the class into a dictionary suitable for export. It might be useful if you don't want
+        every attribute on the model exposed, or if there's some mapping you need to do - for example, 'grade' might be
+        'rank' in your organisation. By default, this method just calls `to_dict_for_output`
+        """
+        return self.to_dict_for_output(depth)
+
     def class_name(self):
         return self.__class__.__name__.lower()
 

--- a/matching/process.py
+++ b/matching/process.py
@@ -159,13 +159,13 @@ def create_mailing_list(
 ):
     """
     This function takes a list of either matched mentors or matched mentees. For each participant, it outputs their
-    data and the information of the participants they've been matched with. If a particpant doesn't have the full
+    data and the information of the participants they've been matched with. If a participant doesn't have the full
     complement of three matches, the empty spaces are ignored.
     """
     file_name = f"{type(participant_list[0]).__str__()}s-list.csv"
     file = output_folder.joinpath(file_name)
     list_participants_as_dicts = [
-        participant.to_dict_for_output() for participant in participant_list
+        participant.to_dict_for_export() for participant in participant_list
     ]
     field_headings = max(
         list_participants_as_dicts, key=lambda participant: len(participant.keys())

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="5.1.3",
+    version="5.1.4",
     description="A series of classes to match mentors and mentees",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Added

- The `Person` base class now has a method `to_dict_for_export`. This could be useful if users want a different
  representation for exporting - for example, if they don't need every attribute on the model, or they want to do
  some calculations before exporting. By default, it just calls `to_dict_for_output`. In a future major version,
  this method will be renamed simply to `to_dict`, to reflect that it's a full representation of the model.